### PR TITLE
Fixed copy/paste error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,17 +181,17 @@ class BlogPostWorkflowSubscriber
 
         $events->listen(
             'Brexis\LaravelWorkflow\Events\LeaveEvent',
-            'App\Listeners\UserEventSubscriber@onLeave'
+            'App\Listeners\BlogPostWorkflowSubscriber@onLeave'
         );
 
         $events->listen(
             'Brexis\LaravelWorkflow\Events\TransitionEvent',
-            'App\Listeners\UserEventSubscriber@onTransition'
+            'App\Listeners\BlogPostWorkflowSubscriber@onTransition'
         );
 
         $events->listen(
             'Brexis\LaravelWorkflow\Events\EnterEvent',
-            'App\Listeners\UserEventSubscriber@onEnter'
+            'App\Listeners\BlogPostWorkflowSubscriber@onEnter'
         );
     }
 


### PR DESCRIPTION
Listeners must be attached to `App\Listeners\BlogPostWorkflowSubscriber`, not `App\Listeners\UserEventSubscriber`