### PR TITLE
fixes deprecated class name warning due to symfony upgrade 3.3

### DIFF
--- a/src/WorkflowRegistry.php
+++ b/src/WorkflowRegistry.php
@@ -13,6 +13,7 @@ use Symfony\Component\Workflow\Registry;
 use Symfony\Component\Workflow\StateMachine;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\Workflow;
+use Symfony\Component\Workflow\SupportStrategy\ClassInstanceSupportStrategy;
 
 /**
  * @author Boris Koumondji <brexis@yahoo.fr>
@@ -55,7 +56,7 @@ class WorkflowRegistry
             $workflow       = $this->getWorkflowInstance($name, $workflowData, $definition, $markingStore);
 
             foreach ($workflowData['supports'] as $supportedClass) {
-                $this->registry->add($workflow, $supportedClass);
+                $this->registry->add($workflow, new ClassInstanceSupportStrategy($supportedClass));
             }
         }
     }


### PR DESCRIPTION
Fixes warning:

"PHP error:  Support of class name string was deprecated after version 3.2 and won't work anymore in 4.0. in /usr/local/sympl/sympl.app2/vendor/symfony/workflow/Registry.php on line 33"

See: https://github.com/symfony/symfony/blob/master/UPGRADE-3.3.md#workflow


