### PR TITLE
emitting symfony-style events to allow for cleaner multiple workflows

### DIFF
--- a/src/Events/WorkflowSubscriber.php
+++ b/src/Events/WorkflowSubscriber.php
@@ -12,19 +12,19 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class WorkflowSubscriber implements EventSubscriberInterface
 {
     public function guardEvent(SymfonyGuardEvent $event) {
-        event(new GuardEvent($event));
+        event('workflow.'.$event->getWorkflowName().'.guard', $event);
     }
 
     public function leaveEvent(Event $event) {
-        event(new LeaveEvent($event));
+        event('workflow.'.$event->getWorkflowName().'.leave', $event);
     }
 
     public function transitionEvent(Event $event) {
-        event(new TransitionEvent($event));
+        event('workflow.'.$event->getWorkflowName().'.transition', $event);
     }
 
     public function enterEvent(Event $event) {
-        event(new EnterEvent($event));
+        event('workflow.'.$event->getWorkflowName().'.enter', $event);
     }
 
     public static function getSubscribedEvents()

--- a/tests/WorkflowSubscriberTest.php
+++ b/tests/WorkflowSubscriberTest.php
@@ -4,6 +4,7 @@ namespace Tests {
     use PHPUnit\Framework\TestCase;
     use Brexis\LaravelWorkflow\WorkflowRegistry;
     use Tests\Fixtures\TestObject;
+    use Illuminate\Support\Facades\Event;
 
     class WorkflowRegistryTest extends TestCase
     {
@@ -34,10 +35,10 @@ namespace Tests {
 
             $workflow->apply($object, 't1');
 
-            $this->assertTrue($events[0] instanceof \Brexis\LaravelWorkflow\Events\GuardEvent);
-            $this->assertTrue($events[1] instanceof \Brexis\LaravelWorkflow\Events\LeaveEvent);
-            $this->assertTrue($events[2] instanceof \Brexis\LaravelWorkflow\Events\TransitionEvent);
-            $this->assertTrue($events[3] instanceof \Brexis\LaravelWorkflow\Events\EnterEvent);
+            $this->assertTrue($events[0] == "workflow.straight.guard");
+            $this->assertTrue($events[1] == "workflow.straight.leave");
+            $this->assertTrue($events[2] == "workflow.straight.transition");
+            $this->assertTrue($events[3] == "workflow.straight.enter");
         }
     }
 }


### PR DESCRIPTION
When multiple workflows are used, every listener has to duplicate a check on whether or not it is relevant to this listener and model. By dispatching events similar to symfony, we can listen only to specific events `workflow.flowname.guard`--thus greatly cleaning up the slew of listeners for multiple workflows.