### PR TITLE
Add support for multiple transitions with the same name

### DIFF
--- a/src/WorkflowRegistry.php
+++ b/src/WorkflowRegistry.php
@@ -48,6 +48,10 @@ class WorkflowRegistry
             $builder = new DefinitionBuilder($workflowData['places']);
 
             foreach ($workflowData['transitions'] as $transitionName => $transition) {
+                if (!is_string($transitionName)) {
+                    $transitionName = $transition['name'];
+                }
+
                 $builder->addTransition(new Transition($transitionName, $transition['from'], $transition['to']));
             }
 

--- a/tests/WorkflowDumpCommandTest.php
+++ b/tests/WorkflowDumpCommandTest.php
@@ -5,7 +5,7 @@ namespace Tests {
     use Mockery;
     use PHPUnit\Framework\TestCase;
 
-    class WorkflowRegistryTest extends TestCase
+    class WorkflowDumpCommandTest extends TestCase
     {
         public function testWorkflowCommand()
         {

--- a/tests/WorkflowRegistryTest.php
+++ b/tests/WorkflowRegistryTest.php
@@ -79,4 +79,50 @@ class WorkflowRegistryTest extends TestCase
         $this->assertTrue($workflow instanceof StateMachine);
         $this->assertTrue($markingStore instanceof MultipleStateMarkingStore);
     }
+
+	public function testIfTransitionsWithSameNameCanBothBeUsed()
+	{
+        $config = [
+            'straight' => [
+                'type'        => 'state_machine',
+                'supports'    => ['Tests\Fixtures\TestObject'],
+                'places'      => ['a', 'b', 'c'],
+                'transitions' => [
+                    [
+                        'name' => 't1',
+                        'from' => 'a',
+                        'to'   => 'b',
+                    ],
+                    [
+                        'name' => 't1',
+                        'from' => 'c',
+                        'to'   => 'b',
+                    ],
+                    [
+                        'name' => 't2',
+                        'from' => 'b',
+                        'to'   => 'c',
+                    ]
+                ],
+            ]
+        ];
+
+        $registry = new WorkflowRegistry($config);
+        $subject  = new TestObject;
+        $workflow = $registry->get($subject);
+
+        $markingStoreProp = new ReflectionProperty(Workflow::class, 'markingStore');
+        $markingStoreProp->setAccessible(true);
+
+        $markingStore = $markingStoreProp->getValue($workflow);
+
+        $this->assertTrue($workflow instanceof StateMachine);
+        $this->assertTrue($markingStore instanceof SingleStateMarkingStore);
+        $this->assertTrue($workflow->can($subject, 't1'));
+
+        $workflow->apply($subject, 't1');
+        $workflow->apply($subject, 't2');
+
+        $this->assertTrue($workflow->can($subject, 't1'));
+    }
 }

--- a/tests/WorkflowSubscriberTest.php
+++ b/tests/WorkflowSubscriberTest.php
@@ -6,11 +6,13 @@ namespace Tests {
     use Tests\Fixtures\TestObject;
     use Illuminate\Support\Facades\Event;
 
-    class WorkflowRegistryTest extends TestCase
+    class WorkflowSubscriberTest extends TestCase
     {
-        public function testIfWorkflowIsRegisrter()
+        public function testIfWorkflowEmitsEvents()
         {
             global $events;
+
+            $events = [];
 
             $config     = [
             'straight'   => [


### PR DESCRIPTION
This syntax has been included in Symfony since 3.3, but the config syntax in laravel-workflow doesn't support it.

I've added the alternative syntax referenced in symfony/symfony#22558 and updated the tests to cover it. (This also required fixing the tests, as many of them had the same class name and did not function).

The existing syntax should still work fine.

Example config file for new syntax:

```php
<?php

return [
    'notice' => [
        'type'          => 'state_machine',
        'marking_store' => [
            'arguments' => ['status'],
        ],
        'supports'      => ['App\Notice'],
        'places'        => ['draft', 'published', 'rejected'],
        'transitions'   => [
            [
                'name' => 'approve',
                'from' => 'draft',
                'to'   => 'published',
            ],
            [
                'name' => 'reject',
                'from' => 'draft',
                'to'   => 'rejected',
            ],
            [
                'name' => 'edit',
                'from' => 'published',
                'to'   => 'draft',
            ],
            [
                'name' => 'edit',
                'from' => 'rejected',
                'to'   => 'draft',
            ],
        ],
    ]
];
```

As you can see, two different states can make the 'edit' transition (see diagram below).

![notice](https://user-images.githubusercontent.com/1607874/32950395-111177c2-cb9e-11e7-9237-6876d968815f.png)

To re-iterate, this functionality exists already in Symfony Workflow, this is just to allow it to be used with laravel-workflow.