### PR TITLE
Added entered Event

### DIFF
--- a/src/Events/EnteredEvent.php
+++ b/src/Events/EnteredEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Brexis\LaravelWorkflow\Events;
+
+/**
+ * @author Boris Koumondji <brexis@yahoo.fr>
+ */
+class EnteredEvent extends BaseEvent
+{
+}

--- a/src/Events/WorkflowSubscriber.php
+++ b/src/Events/WorkflowSubscriber.php
@@ -31,13 +31,19 @@ class WorkflowSubscriber implements EventSubscriberInterface
         event('workflow.'.$event->getWorkflowName().'.enter', $event);
     }
 
+    public function enteredEvent(Event $event) {
+        event(new EnteredEvent($event));
+        event('workflow.'.$event->getWorkflowName().'.entered', $event);
+    }
+
     public static function getSubscribedEvents()
     {
         return [
             'workflow.guard'        => ['guardEvent'],
             'workflow.leave'        => ['leaveEvent'],
             'workflow.transition'   => ['transitionEvent'],
-            'workflow.enter'        => ['enterEvent']
+            'workflow.enter'        => ['enterEvent'],
+            'workflow.entered'      => ['enteredEvent'],
         ];
     }
 }

--- a/tests/WorkflowSubscriberTest.php
+++ b/tests/WorkflowSubscriberTest.php
@@ -44,6 +44,8 @@ namespace Tests {
             $this->assertTrue($events[5] == "workflow.straight.transition");
             $this->assertTrue($events[6] instanceof \Brexis\LaravelWorkflow\Events\EnterEvent);
             $this->assertTrue($events[7] == "workflow.straight.enter");
+            $this->assertTrue($events[8] instanceof \Brexis\LaravelWorkflow\Events\EnteredEvent);
+            $this->assertTrue($events[9] == "workflow.straight.entered");
         }
     }
 }


### PR DESCRIPTION
> workflow.entered
> Similar to workflow.enter, except the marking store is updated before this event (making it a good place to flush data in Doctrine).
> 
> The three events being dispatched are:
> 
> workflow.entered
> workflow.[workflow name].entered
> workflow.[workflow name].entered.[place name]

https://symfony.com/doc/current/workflow/usage.html#using-events