### PR TITLE
 Fix workflow_transitions method in WorkflowTrait issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ $post->workflow_can('to_review'); // False
 foreach ($post->workflow_transitions() as $transition) {
     echo $transition->getName();
 }
+// if more than one workflow is defined for the BlogPost class
+foreach ($post->workflow_transitions($workflowName) as $transition) {
+    echo $transition->getName();
+}
 
 // Apply a transition
 $post->workflow_apply('publish');

--- a/src/Traits/WorkflowTrait.php
+++ b/src/Traits/WorkflowTrait.php
@@ -19,8 +19,8 @@ trait WorkflowTrait
         return Workflow::get($this, $workflow)->can($this, $transition);
     }
 
-    public function workflow_transitions()
+    public function workflow_transitions($workflow = null)
     {
-        return Workflow::get($this)->getEnabledTransitions($this);
+        return Workflow::get($this, $workflow)->getEnabledTransitions($this);
     }
 }


### PR DESCRIPTION
Issue : 
   When more than one workflow is defined for the same class the method workflow_transitions gives exception with message "At least two workflows match this subject. Set a different name on each and use the second (name) argument of this method."