### PR TITLE
Update Laravel to v5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "symfony/workflow": "^3.3 || ^4.0",
         "symfony/process": "^3.3 || ^4.0",
         "symfony/event-dispatcher": "^3.3 || ^4.0",
-        "illuminate/console": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.*"
+        "illuminate/console": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
+        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds support for the packages of Laravel 5.7, so this library can be installed for apps running Laravel 5.7.