### PR TITLE
add all() method to the WorkflowRegistry

### DIFF
--- a/src/WorkflowRegistry.php
+++ b/src/WorkflowRegistry.php
@@ -75,9 +75,21 @@ class WorkflowRegistry
      */
     public function add(Workflow $workflow, $supportStrategy)
     {
-        $this->registry->add($workflow, new ClassInstanceSupportStrategy($supportStrategy));
+        $this->registry->addWorkflow($workflow, new ClassInstanceSupportStrategy($supportStrategy));
     }
 
+     /**
+     * Return all workflows for the given $subject
+     *
+     * @param  object $subject
+     * @return Workflow[]
+     */
+    public function all($subject): array
+    {
+        return $this->registry->all($subject);
+    }
+
+    
     /**
      * Add a workflow to the registry from array
      *


### PR DESCRIPTION
added all() method and updated addWorkflow() method because add() was deprecated.