### PR TITLE
Do not load default config and remove useless `$provides` property

### DIFF
--- a/src/WorkflowServiceProvider.php
+++ b/src/WorkflowServiceProvider.php
@@ -34,11 +34,6 @@ class WorkflowServiceProvider extends ServiceProvider
     */
     public function register()
     {
-        $this->mergeConfigFrom(
-            $this->configPath(),
-            'workflow'
-        );
-
         $this->commands($this->commands);
 
         $this->app->singleton(
@@ -51,15 +46,5 @@ class WorkflowServiceProvider extends ServiceProvider
     protected function configPath()
     {
         return __DIR__ . '/../config/workflow.php';
-    }
-
-    /**
-    * Get the services provided by the provider.
-    *
-    * @return array
-    */
-    public function provides()
-    {
-        return ['workflow'];
     }
 }


### PR DESCRIPTION
Default configuration file does not provide usefull configuration item: it should not be loaded, since it adds a workflow called `straight`.

The `$provides` property is only usefull for deferred service providers, to let the Container know where services are defined. Non deferred service providers are always loaded.

Fixes #40 