### PR TITLE
Symfony/Workflow 4.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
     "keywords": ["workflow", "symfony", "laravel", "laravel5"],
     "license": "MIT",
     "require": {
-        "php": ">=5.5.9",
-        "symfony/workflow": "^3.3 || ^4.0",
-        "symfony/process": "^3.3 || ^4.0",
-        "symfony/event-dispatcher": "^3.3 || ^4.0",
-        "illuminate/console": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
-        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*"
+        "php": "^7.1.3",
+        "symfony/workflow": "^4.1",
+        "symfony/process": "^4.1",
+        "symfony/event-dispatcher": "^4.1",
+        "illuminate/console": "5.7.*",
+        "illuminate/support": "5.7.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/WorkflowRegistry.php
+++ b/src/WorkflowRegistry.php
@@ -11,7 +11,7 @@ use Symfony\Component\Workflow\MarkingStore\MultipleStateMarkingStore;
 use Symfony\Component\Workflow\MarkingStore\SingleStateMarkingStore;
 use Symfony\Component\Workflow\Registry;
 use Symfony\Component\Workflow\StateMachine;
-use Symfony\Component\Workflow\SupportStrategy\ClassInstanceSupportStrategy;
+use Symfony\Component\Workflow\SupportStrategy\InstanceOfSupportStrategy;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\Workflow;
 
@@ -75,7 +75,7 @@ class WorkflowRegistry
      */
     public function add(Workflow $workflow, $supportStrategy)
     {
-        $this->registry->add($workflow, new ClassInstanceSupportStrategy($supportStrategy));
+        $this->registry->addWorkflow($workflow, new InstanceOfSupportStrategy($supportStrategy));
     }
 
     /**


### PR DESCRIPTION
Laravel 5.7 uses Symfony/Workflow 4.1 which has deprecations. This PR fixes these deprecations.
Fixes #45 