### PR TITLE
Apply the same requirement rule to symfony/event-dispatcher and other symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.5.9",
         "symfony/workflow": "^3.3 || ^4.0",
         "symfony/process": "^3.3 || ^4.0",
-        "symfony/event-dispatcher": "^3.3 || 4.0.* || 4.1.* || 4.2.*",
+        "symfony/event-dispatcher": "^3.3 || ^4.0",
         "illuminate/console": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
         "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*"
     },

--- a/src/Events/WorkflowSubscriber.php
+++ b/src/Events/WorkflowSubscriber.php
@@ -63,15 +63,17 @@ class WorkflowSubscriber implements EventSubscriberInterface
 
     public function enteredEvent(Event $event)
     {
-        $places       = $event->getTransition()->getTos();
-        $workflowName = $event->getWorkflowName();
+        if (null !== ($transition = $event->getTransition())) {
+            $places       = $transition->getTos();
+            $workflowName = $event->getWorkflowName();
 
-        event(new EnteredEvent($event));
-        event('workflow.entered', $event);
-        event(sprintf('workflow.%s.entered', $workflowName), $event);
+            event(new EnteredEvent($event));
+            event('workflow.entered', $event);
+            event(sprintf('workflow.%s.entered', $workflowName), $event);
 
-        foreach ($places as $place) {
-            event(sprintf('workflow.%s.entered.%s', $workflowName, $place), $event);
+            foreach ($places as $place) {
+                event(sprintf('workflow.%s.entered.%s', $workflowName, $place), $event);
+            }
         }
     }
 

--- a/src/WorkflowRegistry.php
+++ b/src/WorkflowRegistry.php
@@ -47,7 +47,7 @@ class WorkflowRegistry
         $this->config = $config;
         $this->dispatcher = new EventDispatcher();
 
-        $subscriber = new WorkflowSubscriber();
+        $subscriber = new WorkflowSubscriber($this->dispatcher);
         $this->dispatcher->addSubscriber($subscriber);
 
         foreach ($this->config as $name => $workflowData) {

--- a/src/WorkflowRegistry.php
+++ b/src/WorkflowRegistry.php
@@ -47,7 +47,7 @@ class WorkflowRegistry
         $this->config = $config;
         $this->dispatcher = new EventDispatcher();
 
-        $subscriber = new WorkflowSubscriber($this->dispatcher);
+        $subscriber = new WorkflowSubscriber();
         $this->dispatcher->addSubscriber($subscriber);
 
         foreach ($this->config as $name => $workflowData) {


### PR DESCRIPTION
Avoid having to add the new version when a new minor is released (for example 4.3 is out), and standardize the requirements to Symfony components