### PR TITLE
Support Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,15 @@
 {
     "name": "brexis/laravel-workflow",
     "description": "Integerate Symfony Workflow component into Laravel.",
-    "keywords": ["workflow", "symfony", "laravel", "laravel5"],
+    "keywords": ["workflow", "symfony", "laravel", "laravel5", "laravel6"],
     "license": "MIT",
     "require": {
         "php": ">=5.5.9",
         "symfony/workflow": "^3.3 || ^4.0",
         "symfony/process": "^3.3 || ^4.0",
         "symfony/event-dispatcher": "^3.3 || ^4.0",
-        "illuminate/console": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
-        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*"
+        "illuminate/console": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || 6.*",
+        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || 6.*"
     },
     "autoload": {
         "psr-4": {
@@ -36,6 +36,6 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^6.0 || ~7.0"
+        "phpunit/phpunit": "^6.0 || ~7.0 || ^8.0"
     }
 }

--- a/tests/WorkflowSubscriberTest.php
+++ b/tests/WorkflowSubscriberTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests {
 
-    use Brexis\LaravelWorkflow\Events\AnnounceEvent;
     use Brexis\LaravelWorkflow\Events\CompletedEvent;
     use Brexis\LaravelWorkflow\Events\EnteredEvent;
     use Brexis\LaravelWorkflow\Events\EnterEvent;
@@ -44,42 +43,46 @@ namespace Tests {
 
             $workflow->apply($object, 't1');
 
-            $this->assertCount(28, $events);
+            $this->assertCount(31, $events);
 
-            $this->assertInstanceOf(GuardEvent::class, $events[0]);
-            $this->assertEquals('workflow.guard', $events[1]);
-            $this->assertEquals('workflow.straight.guard', $events[2]);
-            $this->assertEquals('workflow.straight.guard.t1', $events[3]);
+            $this->assertInstanceOf(EnteredEvent::class, $events[0]);
+            $this->assertEquals('workflow.entered', $events[1]);
+            $this->assertEquals('workflow.straight.entered', $events[2]);
 
-            $this->assertInstanceOf(LeaveEvent::class, $events[4]);
-            $this->assertEquals('workflow.leave', $events[5]);
-            $this->assertEquals('workflow.straight.leave', $events[6]);
-            $this->assertEquals('workflow.straight.leave.a', $events[7]);
+            $this->assertInstanceOf(GuardEvent::class, $events[3]);
+            $this->assertEquals('workflow.guard', $events[4]);
+            $this->assertEquals('workflow.straight.guard', $events[5]);
+            $this->assertEquals('workflow.straight.guard.t1', $events[6]);
 
-            $this->assertInstanceOf(TransitionEvent::class, $events[8]);
-            $this->assertEquals('workflow.transition', $events[9]);
-            $this->assertEquals('workflow.straight.transition', $events[10]);
-            $this->assertEquals('workflow.straight.transition.t1', $events[11]);
+            $this->assertInstanceOf(LeaveEvent::class, $events[7]);
+            $this->assertEquals('workflow.leave', $events[8]);
+            $this->assertEquals('workflow.straight.leave', $events[9]);
+            $this->assertEquals('workflow.straight.leave.a', $events[10]);
 
-            $this->assertInstanceOf(EnterEvent::class, $events[12]);
-            $this->assertEquals('workflow.enter', $events[13]);
-            $this->assertEquals('workflow.straight.enter', $events[14]);
-            $this->assertEquals('workflow.straight.enter.b', $events[15]);
+            $this->assertInstanceOf(TransitionEvent::class, $events[11]);
+            $this->assertEquals('workflow.transition', $events[12]);
+            $this->assertEquals('workflow.straight.transition', $events[13]);
+            $this->assertEquals('workflow.straight.transition.t1', $events[14]);
 
-            $this->assertInstanceOf(EnteredEvent::class, $events[16]);
-            $this->assertEquals('workflow.entered', $events[17]);
-            $this->assertEquals('workflow.straight.entered', $events[18]);
-            $this->assertEquals('workflow.straight.entered.b', $events[19]);
+            $this->assertInstanceOf(EnterEvent::class, $events[15]);
+            $this->assertEquals('workflow.enter', $events[16]);
+            $this->assertEquals('workflow.straight.enter', $events[17]);
+            $this->assertEquals('workflow.straight.enter.b', $events[18]);
 
-            $this->assertInstanceOf(CompletedEvent::class, $events[20]);
-            $this->assertEquals('workflow.completed', $events[21]);
-            $this->assertEquals('workflow.straight.completed', $events[22]);
-            $this->assertEquals('workflow.straight.completed.t1', $events[23]);
+            $this->assertInstanceOf(EnteredEvent::class, $events[19]);
+            $this->assertEquals('workflow.entered', $events[20]);
+            $this->assertEquals('workflow.straight.entered', $events[21]);
+            $this->assertEquals('workflow.straight.entered.b', $events[22]);
 
-            $this->assertInstanceOf(GuardEvent::class, $events[24]);
-            $this->assertEquals('workflow.guard', $events[25]);
-            $this->assertEquals('workflow.straight.guard', $events[26]);
-            $this->assertEquals('workflow.straight.guard.t2', $events[27]);
+            $this->assertInstanceOf(CompletedEvent::class, $events[23]);
+            $this->assertEquals('workflow.completed', $events[24]);
+            $this->assertEquals('workflow.straight.completed', $events[25]);
+            $this->assertEquals('workflow.straight.completed.t1', $events[26]);
+
+            $this->assertInstanceOf(GuardEvent::class, $events[27]);
+            $this->assertEquals('workflow.guard', $events[28]);
+            $this->assertEquals('workflow.straight.guard', $events[29]);
+            $this->assertEquals('workflow.straight.guard.t2', $events[30]);
         }
     }
 }


### PR DESCRIPTION
Add support for Laravel 6.

This also fixes the broken test that was introduced by commit https://github.com/brexis/laravel-workflow/commit/525274e7de17a18bf21cb5a770b3aec59d239d7f.