### PR TITLE
Define the requirement rule for illuminate dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "symfony/workflow": "^3.3 || ^4.0",
         "symfony/process": "^3.3 || ^4.0",
         "symfony/event-dispatcher": "^3.3 || ^4.0",
-        "illuminate/console": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
-        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*"
+        "illuminate/console": "^5.3|| 6.0.*",
+        "illuminate/support": "^5.3|| 6.0.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
illuminate/console and illuminate/support (version 6.0) has been released and being used in Laravel V6.0.