### PR TITLE
Have `workflow_transitions` return collection

### DIFF
--- a/src/Traits/WorkflowTrait.php
+++ b/src/Traits/WorkflowTrait.php
@@ -21,6 +21,6 @@ trait WorkflowTrait
 
     public function workflow_transitions($workflow = null)
     {
-        return Workflow::get($this, $workflow)->getEnabledTransitions($this);
+        return collect(Workflow::get($this, $workflow)->getEnabledTransitions($this));
     }
 }


### PR DESCRIPTION
This is a quality of life improvement for developers who want to lean on Laravel's collections. I currently wrap the return of this function in a collection and would like the ability to have it function that way out of the box.

I don't believe this will introduce regressions in existing code.