### PR TITLE
Add support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,15 @@
 {
     "name": "brexis/laravel-workflow",
     "description": "Integerate Symfony Workflow component into Laravel.",
-    "keywords": ["workflow", "symfony", "laravel", "laravel5", "laravel6"],
+    "keywords": ["workflow", "symfony", "laravel", "laravel5", "laravel6", "laravel7"],
     "license": "MIT",
     "require": {
         "php": ">=5.5.9",
-        "symfony/workflow": "^3.3 || ^4.0",
-        "symfony/process": "^3.3 || ^4.0",
-        "symfony/event-dispatcher": "^3.3 || ^4.0",
-        "illuminate/console": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || 6.*",
-        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || 6.*"
+        "symfony/workflow": "^3.3 || ^4.0 || ^5.0",
+        "symfony/process": "^3.3 || ^4.0 || ^5.0",
+        "symfony/event-dispatcher": "^3.3 || ^4.0 || ^5.0",
+        "illuminate/console": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || 6.* || 7.*",
+        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || 6.* || 7.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Commands/WorkflowDumpCommand.php
+++ b/src/Commands/WorkflowDumpCommand.php
@@ -62,7 +62,7 @@ class WorkflowDumpCommand extends Command
 
         $dotCommand = "dot -T$format -o $workflowName.$format";
 
-        $process = new Process($dotCommand);
+        $process = Process::fromShellCommandline($dotCommand);
         $process->setInput($dumper->dump($definition));
         $process->mustRun();
     }

--- a/tests/Fixtures/TestObject.php
+++ b/tests/Fixtures/TestObject.php
@@ -4,4 +4,20 @@ namespace Tests\Fixtures;
 class TestObject
 {
     public $marking;
+
+    /**
+     * @return mixed
+     */
+    public function getMarking()
+    {
+        return $this->marking;
+    }
+
+    /**
+     * @param mixed $marking
+     */
+    public function setMarking($marking)
+    {
+        $this->marking = $marking;
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests {
+
+    /**
+     * Class TestCase
+     *
+     * @package Tests
+     */
+    abstract class TestCase extends \PHPUnit\Framework\TestCase
+    {
+
+    }
+}
+
+namespace {
+
+    if (! function_exists('event')) {
+        $events = null;
+
+        function event($ev)
+        {
+            global $events;
+            $events[] = $ev;
+        }
+    }
+}

--- a/tests/WorkflowDumpCommandTest.php
+++ b/tests/WorkflowDumpCommandTest.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Tests {
 
     use Brexis\LaravelWorkflow\Commands\WorkflowDumpCommand;
     use Mockery;
-    use PHPUnit\Framework\TestCase;
 
     class WorkflowDumpCommandTest extends TestCase
     {

--- a/tests/WorkflowSubscriberTest.php
+++ b/tests/WorkflowSubscriberTest.php
@@ -1,99 +1,86 @@
 <?php
 
-namespace Tests {
+namespace Tests;
 
-    use Brexis\LaravelWorkflow\Events\CompletedEvent;
-    use Brexis\LaravelWorkflow\Events\EnteredEvent;
-    use Brexis\LaravelWorkflow\Events\EnterEvent;
-    use Brexis\LaravelWorkflow\Events\GuardEvent;
-    use Brexis\LaravelWorkflow\Events\LeaveEvent;
-    use Brexis\LaravelWorkflow\Events\TransitionEvent;
-    use PHPUnit\Framework\TestCase;
-    use Brexis\LaravelWorkflow\WorkflowRegistry;
-    use Tests\Fixtures\TestObject;
+use Brexis\LaravelWorkflow\Events\CompletedEvent;
+use Brexis\LaravelWorkflow\Events\EnteredEvent;
+use Brexis\LaravelWorkflow\Events\EnterEvent;
+use Brexis\LaravelWorkflow\Events\GuardEvent;
+use Brexis\LaravelWorkflow\Events\LeaveEvent;
+use Brexis\LaravelWorkflow\Events\TransitionEvent;
+use Brexis\LaravelWorkflow\WorkflowRegistry;
+use Tests\Fixtures\TestObject;
 
-    class WorkflowSubscriberTest extends TestCase
-    {
-        public function testIfWorkflowEmitsEvents()
-        {
-            global $events;
-
-            $events = [];
-
-            $config = [
-                'straight' => [
-                    'supports'    => [TestObject::class],
-                    'places'      => ['a', 'b', 'c'],
-                    'transitions' => [
-                        't1' => [
-                            'from' => 'a',
-                            'to'   => 'b',
-                        ],
-                        't2' => [
-                            'from' => 'b',
-                            'to'   => 'c',
-                        ],
-                    ],
-                ],
-            ];
-
-            $registry = new WorkflowRegistry($config);
-            $object = new TestObject;
-            $workflow = $registry->get($object);
-
-            $workflow->apply($object, 't1');
-
-            $this->assertCount(31, $events);
-
-            $this->assertInstanceOf(EnteredEvent::class, $events[0]);
-            $this->assertEquals('workflow.entered', $events[1]);
-            $this->assertEquals('workflow.straight.entered', $events[2]);
-
-            $this->assertInstanceOf(GuardEvent::class, $events[3]);
-            $this->assertEquals('workflow.guard', $events[4]);
-            $this->assertEquals('workflow.straight.guard', $events[5]);
-            $this->assertEquals('workflow.straight.guard.t1', $events[6]);
-
-            $this->assertInstanceOf(LeaveEvent::class, $events[7]);
-            $this->assertEquals('workflow.leave', $events[8]);
-            $this->assertEquals('workflow.straight.leave', $events[9]);
-            $this->assertEquals('workflow.straight.leave.a', $events[10]);
-
-            $this->assertInstanceOf(TransitionEvent::class, $events[11]);
-            $this->assertEquals('workflow.transition', $events[12]);
-            $this->assertEquals('workflow.straight.transition', $events[13]);
-            $this->assertEquals('workflow.straight.transition.t1', $events[14]);
-
-            $this->assertInstanceOf(EnterEvent::class, $events[15]);
-            $this->assertEquals('workflow.enter', $events[16]);
-            $this->assertEquals('workflow.straight.enter', $events[17]);
-            $this->assertEquals('workflow.straight.enter.b', $events[18]);
-
-            $this->assertInstanceOf(EnteredEvent::class, $events[19]);
-            $this->assertEquals('workflow.entered', $events[20]);
-            $this->assertEquals('workflow.straight.entered', $events[21]);
-            $this->assertEquals('workflow.straight.entered.b', $events[22]);
-
-            $this->assertInstanceOf(CompletedEvent::class, $events[23]);
-            $this->assertEquals('workflow.completed', $events[24]);
-            $this->assertEquals('workflow.straight.completed', $events[25]);
-            $this->assertEquals('workflow.straight.completed.t1', $events[26]);
-
-            $this->assertInstanceOf(GuardEvent::class, $events[27]);
-            $this->assertEquals('workflow.guard', $events[28]);
-            $this->assertEquals('workflow.straight.guard', $events[29]);
-            $this->assertEquals('workflow.straight.guard.t2', $events[30]);
-        }
-    }
-}
-
-namespace {
-
-    $events = null;
-
-    function event($ev)
+class WorkflowSubscriberTest extends TestCase
+{
+    public function testIfWorkflowEmitsEvents()
     {
         global $events;
-        $events[] = $ev;
+
+        $events = [];
+
+        $config = [
+            'straight' => [
+                'supports'    => [TestObject::class],
+                'places'      => ['a', 'b', 'c'],
+                'transitions' => [
+                    't1' => [
+                        'from' => 'a',
+                        'to'   => 'b',
+                    ],
+                    't2' => [
+                        'from' => 'b',
+                        'to'   => 'c',
+                    ],
+                ],
+            ],
+        ];
+
+        $registry = new WorkflowRegistry($config);
+        $object = new TestObject;
+        $workflow = $registry->get($object);
+
+        $workflow->apply($object, 't1');
+
+        $this->assertCount(31, $events);
+
+        $this->assertInstanceOf(EnteredEvent::class, $events[0]);
+        $this->assertEquals('workflow.entered', $events[1]);
+        $this->assertEquals('workflow.straight.entered', $events[2]);
+
+        $this->assertInstanceOf(GuardEvent::class, $events[3]);
+        $this->assertEquals('workflow.guard', $events[4]);
+        $this->assertEquals('workflow.straight.guard', $events[5]);
+        $this->assertEquals('workflow.straight.guard.t1', $events[6]);
+
+        $this->assertInstanceOf(LeaveEvent::class, $events[7]);
+        $this->assertEquals('workflow.leave', $events[8]);
+        $this->assertEquals('workflow.straight.leave', $events[9]);
+        $this->assertEquals('workflow.straight.leave.a', $events[10]);
+
+        $this->assertInstanceOf(TransitionEvent::class, $events[11]);
+        $this->assertEquals('workflow.transition', $events[12]);
+        $this->assertEquals('workflow.straight.transition', $events[13]);
+        $this->assertEquals('workflow.straight.transition.t1', $events[14]);
+
+        $this->assertInstanceOf(EnterEvent::class, $events[15]);
+        $this->assertEquals('workflow.enter', $events[16]);
+        $this->assertEquals('workflow.straight.enter', $events[17]);
+        $this->assertEquals('workflow.straight.enter.b', $events[18]);
+
+        $this->assertInstanceOf(EnteredEvent::class, $events[19]);
+        $this->assertEquals('workflow.entered', $events[20]);
+        $this->assertEquals('workflow.straight.entered', $events[21]);
+        $this->assertEquals('workflow.straight.entered.b', $events[22]);
+
+        $this->assertInstanceOf(CompletedEvent::class, $events[23]);
+        $this->assertEquals('workflow.completed', $events[24]);
+        $this->assertEquals('workflow.straight.completed', $events[25]);
+        $this->assertEquals('workflow.straight.completed.t1', $events[26]);
+
+        $this->assertInstanceOf(GuardEvent::class, $events[27]);
+        $this->assertEquals('workflow.guard', $events[28]);
+        $this->assertEquals('workflow.straight.guard', $events[29]);
+        $this->assertEquals('workflow.straight.guard.t2', $events[30]);
     }
 }


### PR DESCRIPTION
Based on the code in #73, I've created my own branch with some small fixes. This should be backwards compatible with the marking store config and also support a newer format.

Old:
```php
'marking_store' => [
    'type' => 'single_state',
    'arguments' => ['currentPlace'],
],
```

New:
```php
'marking_store' => [
    'arguments' => [true, 'currentPlace'],
],
```

You can use my fork by changing your `composer.json` and running `composer update brexis/laravel-workflow`:

```json
"require": {
    "brexis/laravel-workflow": "dev-laravel-7-support"
},
"repositories": [
    {
        "type": "vcs",
        "url": "git@github.com:willemo/laravel-workflow.git"
    }
]
```